### PR TITLE
Fix Numeric to i32 on next_redeem_at

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -18,7 +18,7 @@ pub async fn get_redeemable_subscriptions(
                 amount::NUMERIC as amount,
                 category,
                 frequency::NUMERIC as frequency,
-                creation_timestamp::NUMERIC as creation_timestamp
+                creation_timestamp::INTEGER as creation_timestamp
             FROM subindexer_subscription_module.subscription_created active
                     LEFT JOIN subindexer_subscription_module.unsubscribed canceled
                             ON active.id = canceled.id
@@ -27,8 +27,8 @@ pub async fn get_redeemable_subscriptions(
         latest_redemptions AS (
             SELECT DISTINCT ON (id)
                 id,
-                next_redeem_at,
-                block_number as last_redeemed
+                next_redeem_at::INTEGER as next_redeem_at,
+                block_number::INTEGER as last_redeemed
             FROM subindexer_subscription_module.redeemed
             ORDER BY id, next_redeem_at DESC
         ),
@@ -39,22 +39,22 @@ pub async fn get_redeemable_subscriptions(
             FROM subindexer_subscription_module.recipient_updated
             ORDER BY id, block_number DESC
         ),
-        upcomming AS (
+        upcoming AS (
             SELECT
                 a.id,
                 a.subscriber,
                 COALESCE(rp.new_recipient, a.recipient) AS recipient,
                 -- Redeemable Amount: cf https://github.com/deluXtreme/subi-contracts/blob/65455f02e3e7a49654c51b9b5e805cccc1032168/src/SubscriptionModule.sol#L154-L158
-                (FLOOR((FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC - COALESCE(cast(r.last_redeemed as Integer), creation_timestamp)) / a.frequency) * a.amount)::TEXT as amount,
+                (FLOOR((FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC - COALESCE(r.last_redeemed, creation_timestamp)) / a.frequency) * a.amount)::TEXT as amount,
                 category,
-                COALESCE(cast(r.next_redeem_at as Integer), creation_timestamp) AS next_redeem_at
+                COALESCE(r.next_redeem_at, creation_timestamp) AS next_redeem_at
             FROM active_subscriptions a
                     LEFT JOIN latest_redemptions r
                             ON a.id = r.id
                     LEFT JOIN latest_recipients rp
                             ON a.id = rp.id
         )
-    SELECT * from upcomming
+    SELECT * from upcoming
     WHERE next_redeem_at < $1;
     "#;
 

--- a/src/redeemable-subscriptions.sql
+++ b/src/redeemable-subscriptions.sql
@@ -7,7 +7,7 @@ WITH
             amount::NUMERIC as amount,
             category,
             frequency::NUMERIC as frequency,
-            creation_timestamp::NUMERIC as creation_timestamp
+            creation_timestamp::INTEGER as creation_timestamp
         FROM subindexer_subscription_module.subscription_created active
                  LEFT JOIN subindexer_subscription_module.unsubscribed canceled
                            ON active.id = canceled.id
@@ -16,8 +16,8 @@ WITH
     latest_redemptions AS (
         SELECT DISTINCT ON (id)
             id,
-            next_redeem_at,
-            block_number as last_redeemed
+            next_redeem_at::INTEGER as next_redeem_at,
+            block_number::INTEGER as last_redeemed
         FROM subindexer_subscription_module.redeemed
         ORDER BY id, next_redeem_at DESC
     ),
@@ -28,20 +28,20 @@ WITH
         FROM subindexer_subscription_module.recipient_updated
         ORDER BY id, block_number DESC
     ),
-    upcomming AS (
+    upcoming AS (
         SELECT
             a.id,
             a.subscriber,
             COALESCE(rp.new_recipient, a.recipient) AS recipient,
             -- Redeemable Amount: cf https://github.com/deluXtreme/subi-contracts/blob/65455f02e3e7a49654c51b9b5e805cccc1032168/src/SubscriptionModule.sol#L154-L158
-            (FLOOR((FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC - COALESCE(cast(r.last_redeemed as Integer), creation_timestamp)) / a.frequency) * a.amount)::TEXT as amount,
+            (FLOOR((FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC - COALESCE(r.last_redeemed, creation_timestamp)) / a.frequency) * a.amount)::TEXT as amount,
             category,
-            COALESCE(cast(r.next_redeem_at as Integer), creation_timestamp) AS next_redeem_at
+            COALESCE(r.next_redeem_at, creation_timestamp) AS next_redeem_at
         FROM active_subscriptions a
                 LEFT JOIN latest_redemptions r
                         ON a.id = r.id
                 LEFT JOIN latest_recipients rp
                         ON a.id = rp.id
     )
-SELECT * from upcomming
+SELECT * from upcoming
 WHERE next_redeem_at < $1;

--- a/src/redeemable-subscriptions.sql
+++ b/src/redeemable-subscriptions.sql
@@ -34,7 +34,7 @@ WITH
             a.subscriber,
             COALESCE(rp.new_recipient, a.recipient) AS recipient,
             -- Redeemable Amount: cf https://github.com/deluXtreme/subi-contracts/blob/65455f02e3e7a49654c51b9b5e805cccc1032168/src/SubscriptionModule.sol#L154-L158
-            (FLOOR((FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC - COALESCE(r.last_redeemed, creation_timestamp)) / a.frequency) * a.amount)::TEXT as amount,
+            (FLOOR((FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC - COALESCE(r.last_redeemed, creation_timestamp - frequency)) / a.frequency) * a.amount)::TEXT as amount,
             category,
             COALESCE(r.next_redeem_at, creation_timestamp) AS next_redeem_at
         FROM active_subscriptions a


### PR DESCRIPTION
We were seeing this error on the indexer (related to the creation timestamp being Numeric)

```
Database error: error occurred while decoding column "next_redeem_at": mismatched types; Rust type `i32` (as SQL type `INT4`) is not compatible with SQL type `NUMERIC`
```

This PR Resolves that.

Note also that since we can redeem immediately from creation, we must deduct one frequency from the creation timestamp for the amount to be non-zero.