### PR TITLE
Expose Redeem Periods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,12 @@
-
-# Load .env file if it exists
-ifneq (,$(wildcard .env))
-    include .env
-    export
-endif
-
+# Load env file and populate the indexer config template with secrets.
 rindexer.yaml: rindexer.yaml.template .env
 	export $$(grep -v '^#' .env | xargs) && envsubst < rindexer.yaml.template > rindexer.yaml
 
-
 up: rindexer.yaml
 	docker-compose up -d
+
+build-up: rindexer.yaml
+	docker-compose up -d --build
 
 down:
 	docker-compose down

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,65 +1,18 @@
 use crate::models::RedeemableSubscription;
 use sqlx::PgPool;
+use tokio::fs;
+
+const QUERY_PATH: &str = "src/redeemable-subscriptions.sql";
 
 pub async fn get_redeemable_subscriptions(
     pool: &PgPool,
     current_timestamp: i32,
 ) -> Result<Vec<RedeemableSubscription>, sqlx::Error> {
-    // TODO: Use the SQL file instead of the inline query (requires fs).
-    // let query = fs::read_to_string("src/redeemable-subscriptions.sql")
-    // .expect("Failed to read redeemable-subscriptions.sql");
-    let query = r#"
-    WITH
-        active_subscriptions as (
-            SELECT
-                active.id,
-                active.subscriber,
-                recipient,
-                amount::NUMERIC as amount,
-                category,
-                frequency::INTEGER as frequency,
-                FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC as right_meow,
-                creation_timestamp::INTEGER as creation_timestamp
-            FROM subindexer_subscription_module.subscription_created active
-                    LEFT JOIN subindexer_subscription_module.unsubscribed canceled
-                            ON active.id = canceled.id
-            WHERE canceled.id IS NULL
-        ),
-        latest_redemptions AS (
-            SELECT DISTINCT ON (id)
-                id,
-                next_redeem_at::INTEGER as next_redeem_at
-            FROM subindexer_subscription_module.redeemed
-            ORDER BY id, next_redeem_at DESC
-        ),
-        latest_recipients AS (
-            SELECT DISTINCT ON (id)
-                id,
-                new_recipient
-            FROM subindexer_subscription_module.recipient_updated
-            ORDER BY id, block_number DESC
-        ),
-        upcoming AS (
-            SELECT
-                a.id,
-                a.subscriber,
-                COALESCE(rp.new_recipient, a.recipient) AS recipient,
-                amount,
-                -- Redeemable Periods: cf https://github.com/deluXtreme/subi-contracts/blob/65455f02e3e7a49654c51b9b5e805cccc1032168/src/SubscriptionModule.sol#L154-L158
-                FLOOR((right_meow - COALESCE(r.next_redeem_at, creation_timestamp) + frequency) / a.frequency) as periods,
-                category,
-                COALESCE(r.next_redeem_at, creation_timestamp) AS next_redeem_at
-            FROM active_subscriptions a
-                    LEFT JOIN latest_redemptions r
-                            ON a.id = r.id
-                    LEFT JOIN latest_recipients rp
-                            ON a.id = rp.id
-        )
-    SELECT * from upcoming
-    WHERE next_redeem_at < $1;
-    "#;
+    let query = fs::read_to_string(QUERY_PATH)
+        .await
+        .unwrap_or_else(|e| panic!("Failed to read SQL file at '{QUERY_PATH}': {e}"));
 
-    sqlx::query_as::<_, RedeemableSubscription>(query)
+    sqlx::query_as::<_, RedeemableSubscription>(&query)
         .bind(current_timestamp)
         .fetch_all(pool)
         .await

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,6 +8,7 @@ pub struct RedeemableSubscription {
     pub subscriber: String,
     pub recipient: String,
     pub amount: String,
+    pub periods: i32,
     pub category: Category,
     pub next_redeem_at: i32,
 }

--- a/src/redeemable-subscriptions.sql
+++ b/src/redeemable-subscriptions.sql
@@ -4,10 +4,10 @@ WITH
             active.id,
             active.subscriber,
             recipient,
-            amount::NUMERIC as amount,
+            amount,
             category,
             frequency::INTEGER as frequency,
-            FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC as right_meow,
+            FLOOR(EXTRACT(EPOCH FROM now())) as right_meow,
             creation_timestamp::INTEGER as creation_timestamp
         FROM subindexer_subscription_module.subscription_created active
                  LEFT JOIN subindexer_subscription_module.unsubscribed canceled
@@ -35,7 +35,7 @@ WITH
             COALESCE(rp.new_recipient, a.recipient) AS recipient,
             amount,
             -- Redeemable Periods: cf https://github.com/deluXtreme/subi-contracts/blob/65455f02e3e7a49654c51b9b5e805cccc1032168/src/SubscriptionModule.sol#L154-L158
-            FLOOR((right_meow - COALESCE(r.next_redeem_at, creation_timestamp) + frequency) / a.frequency) as periods,
+            FLOOR((right_meow - COALESCE(r.next_redeem_at, creation_timestamp) + frequency) / a.frequency)::INTEGER as periods,
             category,
             COALESCE(r.next_redeem_at, creation_timestamp) AS next_redeem_at
         FROM active_subscriptions a

--- a/src/redeemable-subscriptions.sql
+++ b/src/redeemable-subscriptions.sql
@@ -7,6 +7,7 @@ WITH
             amount::NUMERIC as amount,
             category,
             frequency::INTEGER as frequency,
+            FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC as right_meow,
             creation_timestamp::INTEGER as creation_timestamp
         FROM subindexer_subscription_module.subscription_created active
                  LEFT JOIN subindexer_subscription_module.unsubscribed canceled
@@ -16,8 +17,7 @@ WITH
     latest_redemptions AS (
         SELECT DISTINCT ON (id)
             id,
-            next_redeem_at::INTEGER as next_redeem_at,
-            block_number::INTEGER as last_redeemed
+            next_redeem_at::INTEGER as next_redeem_at
         FROM subindexer_subscription_module.redeemed
         ORDER BY id, next_redeem_at DESC
     ),
@@ -33,8 +33,9 @@ WITH
             a.id,
             a.subscriber,
             COALESCE(rp.new_recipient, a.recipient) AS recipient,
-            -- Redeemable Amount: cf https://github.com/deluXtreme/subi-contracts/blob/65455f02e3e7a49654c51b9b5e805cccc1032168/src/SubscriptionModule.sol#L154-L158
-            (FLOOR((FLOOR(EXTRACT(EPOCH FROM now()))::NUMERIC - COALESCE(r.last_redeemed, creation_timestamp - frequency)) / a.frequency) * a.amount)::TEXT as amount,
+            amount,
+            -- Redeemable Periods: cf https://github.com/deluXtreme/subi-contracts/blob/65455f02e3e7a49654c51b9b5e805cccc1032168/src/SubscriptionModule.sol#L154-L158
+            FLOOR((right_meow - COALESCE(r.next_redeem_at, creation_timestamp) + frequency) / a.frequency) as periods,
             category,
             COALESCE(r.next_redeem_at, creation_timestamp) AS next_redeem_at
         FROM active_subscriptions a


### PR DESCRIPTION
Number were becoming too large to for postgres to be reliable. Decided to keep amount as a string without any arithmetic and return the total "periods". 

Also, took the opportunity to stop having two copies of the DB query hanging around.